### PR TITLE
feat: add copy-to-clipboard button to JSON page

### DIFF
--- a/content.js
+++ b/content.js
@@ -89,12 +89,43 @@
       container.appendChild(codeBlock);
       body.appendChild(container);
 
+      // Add copy-to-clipboard button
+      addCopyButton(prettyJson);
+
       // Apply theme
       applyTheme(currentTheme);
 
     } catch (e) {
       console.error('Failed to parse JSON:', e);
     }
+  }
+
+  function addCopyButton(jsonText) {
+    const COPY_ICON = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+    const CHECK_ICON = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
+
+    const button = document.createElement('button');
+    button.className = 'json-copy-button';
+    button.title = 'Copy JSON';
+    button.setAttribute('aria-label', 'Copy JSON to clipboard');
+    button.innerHTML = COPY_ICON;
+
+    let resetTimer = null;
+    button.addEventListener('click', function() {
+      navigator.clipboard.writeText(jsonText).then(function() {
+        button.innerHTML = CHECK_ICON;
+        button.classList.add('copied');
+        clearTimeout(resetTimer);
+        resetTimer = setTimeout(function() {
+          button.innerHTML = COPY_ICON;
+          button.classList.remove('copied');
+        }, 1500);
+      }).catch(function(e) {
+        console.error('Failed to copy JSON:', e);
+      });
+    });
+
+    document.body.appendChild(button);
   }
 
   function highlightJson(line) {

--- a/styles/content.css
+++ b/styles/content.css
@@ -83,6 +83,36 @@
   color: var(--json-punctuation);
 }
 
+/* Copy-to-clipboard button */
+.json-copy-button {
+  position: fixed;
+  top: 12px;
+  right: 16px;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  color: var(--json-foreground);
+  background-color: var(--json-selection);
+  border: 1px solid var(--json-lineNumbers);
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+.json-copy-button:hover {
+  opacity: 1;
+}
+
+.json-copy-button.copied {
+  color: var(--json-string);
+  opacity: 1;
+}
+
 /* Selection highlighting */
 ::selection {
   background-color: var(--json-selection);


### PR DESCRIPTION
## Summary
- Adds a minimal floating SVG copy button (top-right) to the formatted JSON page
- Copies the pretty-printed JSON via `navigator.clipboard.writeText`
- Swaps to a checkmark for 1.5s on success; reuses existing theme CSS vars
- No new manifest permissions needed (clipboard write works in a user-gesture handler)

## Test plan
- Load unpacked extension via `chrome://extensions/`
- Open any `application/json` response or `.json` URL
- Click the top-right button → JSON lands on clipboard, icon flips to a checkmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)