### PR TITLE
chore(ci): bump actions/checkout v4 -> v5

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,7 +11,7 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update manifest.json version
         run: |


### PR DESCRIPTION
## Summary

`actions/checkout@v4` targets Node 20, which GitHub deprecated — runners now
force it onto Node 24 and annotate every run. `v5` targets Node 24 natively.
No input or behaviour change; the annotation goes away.

Part of a sweep across every mbarlow repo with a workflow, so the pins stay
uniform rather than drifting one repo at a time.

## Test plan

- [x] Diff is checkout pins only — verified line-for-line, no other file touched
- [ ] CI green on this PR (where this repo's workflows trigger on PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2zHWe59ykBqm4jryk7ZH8